### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,13 @@
+name: 'Setup Bun and Dependencies'
+description: 'Setup Bun runtime and install project dependencies'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Bun 🥟
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - name: Install dependencies 📦
+      run: bun install
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: Quality
+
+on: pull_request
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+          
+      - name: Run format check 🖌
+        run: bun run format:check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run lint check 🧹
+        run: bun run lint:check
+
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run type check 🔍
+        run: bun run type:check
+
+  spell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run spell check 📝
+        run: bun run spell:check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install Playwright browsers 🎭
+        run: bunx playwright install chromium
+
+      - name: Run tests 🧪
+        run: bun run test:check


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for CI that runs all `:check` scripts in parallel
- Each check job (format, lint, type, spell, test) runs independently for faster feedback
- Uses Bun for efficient dependency management and caching
- Includes Playwright browser installation for browser-based tests

## Test plan
- [x] Workflow file follows GitHub Actions best practices
- [x] All `:check` scripts from package.json are covered
- [ ] Verify workflow runs successfully on PR creation

🤖 Generated with [Claude Code](https://claude.ai/code)